### PR TITLE
Don't scroll the chat room view when showing the "is typing" indicator

### DIFF
--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
@@ -339,8 +339,6 @@ extern const CGFloat kTextContentViewHeight;
     textView.text = nil;
     [textView.undoManager removeAllActions];
 
-    [[NSNotificationCenter defaultCenter] postNotificationName:UITextViewTextDidChangeNotification object:textView];
-
     [self scrollToBottomAnimated:animated];
 }
 

--- a/JSQMessagesViewController/Views/MEGAInputToolbar.m
+++ b/JSQMessagesViewController/Views/MEGAInputToolbar.m
@@ -24,6 +24,8 @@ static NSString * const kMEGAUIKeyInputCarriageReturn = @"\r";
 @property (nonatomic) MEGAToolbarSelectedAssets *selectedAssets;
 @property (nonatomic) NSMutableArray<PHAsset *> *selectedAssetsArray;
 
+@property (nonatomic) CGFloat currentToolbarHeight;
+
 @end
 
 
@@ -344,12 +346,13 @@ static NSString * const kMEGAUIKeyInputCarriageReturn = @"\r";
 }
 
 - (void)resizeToolbarIfNeeded {
-    self.contentView.contentViewHeightConstraint.constant = [self heightToFitInWidth:self.contentView.textView.frame.size.width];
-    CGFloat newToolbarHeight = self.contentView.contentViewHeightConstraint.constant;
-    if (!self.contentView.typingIndicatorView.isHidden) {
-        newToolbarHeight += self.contentView.typingIndicatorView.frame.size.height;
+    CGFloat newToolbarHeight = [self heightToFitInWidth:self.contentView.textView.frame.size.width];
+    if (self.currentToolbarHeight != newToolbarHeight) {
+        self.contentView.contentViewHeightConstraint.constant = newToolbarHeight;
+        [self.delegate messagesInputToolbar:self needsResizeToHeight:newToolbarHeight];
+        
+        self.currentToolbarHeight = newToolbarHeight;
     }
-    [self.delegate messagesInputToolbar:self needsResizeToHeight:newToolbarHeight];
 }
 
 - (CGFloat)heightToFitInWidth:(CGFloat)width {

--- a/JSQMessagesViewController/Views/MEGAToolbarTextContentView.xib
+++ b/JSQMessagesViewController/Views/MEGAToolbarTextContentView.xib
@@ -166,12 +166,12 @@
                 <constraint firstItem="xo0-If-lXN" firstAttribute="trailing" secondItem="woe-C0-kGZ" secondAttribute="trailing" id="3D4-3x-Rry"/>
                 <constraint firstItem="fDU-tM-mKk" firstAttribute="leading" secondItem="Q9K-U3-wwY" secondAttribute="trailing" constant="17" id="3Ww-K1-t4g"/>
                 <constraint firstItem="FzB-DF-mS3" firstAttribute="top" secondItem="BfD-Cm-wk4" secondAttribute="bottom" constant="9" id="4wT-qD-B1O"/>
-                <constraint firstItem="78h-wA-dTN" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="8l3-eC-f4V"/>
                 <constraint firstItem="78h-wA-dTN" firstAttribute="leading" secondItem="woe-C0-kGZ" secondAttribute="leading" id="Fb4-gj-Dw7"/>
                 <constraint firstItem="Mas-Ji-t8P" firstAttribute="leading" secondItem="fDU-tM-mKk" secondAttribute="trailing" constant="17" id="PFv-NL-X6q"/>
                 <constraint firstItem="gYs-hW-CRP" firstAttribute="leading" secondItem="woe-C0-kGZ" secondAttribute="leading" id="Sci-h1-FB0"/>
                 <constraint firstItem="woe-C0-kGZ" firstAttribute="trailing" secondItem="FzB-DF-mS3" secondAttribute="trailing" constant="17" id="aKu-sw-8Ot"/>
                 <constraint firstItem="gYs-hW-CRP" firstAttribute="bottom" secondItem="woe-C0-kGZ" secondAttribute="bottom" id="bYG-bB-lFT"/>
+                <constraint firstItem="xo0-If-lXN" firstAttribute="top" secondItem="78h-wA-dTN" secondAttribute="bottom" id="hmc-3o-Xhc"/>
                 <constraint firstItem="xo0-If-lXN" firstAttribute="leading" secondItem="woe-C0-kGZ" secondAttribute="leading" id="niJ-Ya-l4y"/>
                 <constraint firstItem="gYs-hW-CRP" firstAttribute="trailing" secondItem="woe-C0-kGZ" secondAttribute="trailing" id="oKD-T8-rOn"/>
                 <constraint firstItem="woe-C0-kGZ" firstAttribute="bottom" secondItem="xo0-If-lXN" secondAttribute="bottom" id="oOy-h5-cpy"/>


### PR DESCRIPTION
- There are UI issues when changing the constraint due to the typing change while the collection view is scrolling because the peer sent the message. The scroll to bottom triggered on message received is cancelled due to the change in the constraint, and the new message can't be seen if the user does not scroll (it would be under the toolbar).
- Don't resize the toolbar if it keeps its height between calls to `resizeToolbarIfNeeded`.
- Constraint the typing view to the bottom instead of the top to avoid another UI issue.
- Removed unneeded notification.