### PR TITLE
Bug/#13090 iOS 13 selected image disappears from collection view

### DIFF
--- a/JSQMessagesViewController/Views/MEGAToolbarSelectedAssets.m
+++ b/JSQMessagesViewController/Views/MEGAToolbarSelectedAssets.m
@@ -40,7 +40,9 @@ CGFloat kSelectedAssetCellSquareSize = 134.0f;
 - (void)setSelectionTo:(NSMutableArray<PHAsset *> *)selectedAssetsArray {
     self.selectedAssetsArray = selectedAssetsArray;
     [self.collectionView reloadData];
-    if (selectedAssetsArray.count > 0) {
+    
+    NSUInteger numberOfVisibleItems = (NSUInteger) (CGRectGetWidth(self.collectionView.bounds) / kSelectedAssetCellSquareSize);
+    if (selectedAssetsArray.count > numberOfVisibleItems) {
         [self.collectionView scrollToItemAtIndexPath:[NSIndexPath indexPathForItem:self.selectedAssetsArray.count-1 inSection:0] atScrollPosition:UICollectionViewScrollPositionRight animated:YES];
     }
 }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
**Problem**: In iOS 13 when reloading the collection view a scrolling it to the right immediately when there is only 1 item cause the item to animate offscreen.

**Solution**: When all the cells are visible on the screen, we don't have to scroll to the right.

## Issue gif
![](https://user-images.githubusercontent.com/53881615/63906882-8ac62c00-ca6d-11e9-8c10-fee72f0a2909.gif)



Does this close any currently open issues?
------------------------------------------
#13090

Where has this been tested?
---------------------------
**Devices/Simulators:** iPhone XS Max,

**iOS Version:** iOS 13
