### PR TITLE
#13090: iOS 13: Selected image disappears the first time in Chat screen.

### DIFF
--- a/JSQMessagesViewController/Views/MEGAToolbarSelectedAssets.m
+++ b/JSQMessagesViewController/Views/MEGAToolbarSelectedAssets.m
@@ -43,8 +43,8 @@ CGFloat kSelectedAssetCellSquareSize = 134.0f;
     
     dispatch_async(dispatch_get_main_queue(), ^{
         if (selectedAssetsArray.count > 0) {
-            [self.collectionView scrollToItemAtIndexPath:[NSIndexPath indexPathForItem:self.selectedAssetsArray.count-1 inSection:0] atScrollPosition:UICollectionViewScrollPositionRight animated:YES];
-          }
+            [self.collectionView scrollToItemAtIndexPath:[NSIndexPath indexPathForItem:self.selectedAssetsArray.count - 1 inSection:0] atScrollPosition:UICollectionViewScrollPositionRight animated:YES];
+        }
     });
 }
 

--- a/JSQMessagesViewController/Views/MEGAToolbarSelectedAssets.m
+++ b/JSQMessagesViewController/Views/MEGAToolbarSelectedAssets.m
@@ -40,9 +40,12 @@ CGFloat kSelectedAssetCellSquareSize = 134.0f;
 - (void)setSelectionTo:(NSMutableArray<PHAsset *> *)selectedAssetsArray {
     self.selectedAssetsArray = selectedAssetsArray;
     [self.collectionView reloadData];
-    if (selectedAssetsArray.count > 0) {
-        [self.collectionView scrollToItemAtIndexPath:[NSIndexPath indexPathForItem:self.selectedAssetsArray.count-1 inSection:0] atScrollPosition:UICollectionViewScrollPositionRight animated:YES];
-    }
+    
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (selectedAssetsArray.count > 0) {
+            [self.collectionView scrollToItemAtIndexPath:[NSIndexPath indexPathForItem:self.selectedAssetsArray.count-1 inSection:0] atScrollPosition:UICollectionViewScrollPositionRight animated:YES];
+          }
+    });
 }
 
 - (void)reloadUI {


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
**Problem:** In iOS 13 when reloading the collection view and scrolling it to the right immediately when there is only 1 item cause the item to animate offscreen. 

**Solution:** Using G.C.D. to add the the scroll to main queue will allow some time for collection view to reload.

## Issue gif
![](https://user-images.githubusercontent.com/53881615/63906882-8ac62c00-ca6d-11e9-8c10-fee72f0a2909.gif)



Does this close any currently open issues?
------------------------------------------
#13090

Where has this been tested?
---------------------------
**Devices/Simulators:** iPhone XS Max,

**iOS Version:** iOS 13
