### PR TITLE
#13280: iOS 13 Not able to input text in chat screen.

### DIFF
--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
@@ -774,8 +774,14 @@ extern const CGFloat kTextContentViewHeight;
 }
 
 - (void)messagesInputToolbar:(MEGAInputToolbar *)toolbar needsResizeToHeight:(CGFloat)newToolbarHeight {
+    CGFloat bottomPadding = 0;
+    if (@available(iOS 11.0, *)) {
+        UIWindow *window = UIApplication.sharedApplication.keyWindow;
+        bottomPadding = window.safeAreaInsets.bottom;
+    }
+    
     [UIView animateWithDuration:0.3 animations:^{
-        self.toolbarHeightConstraint.constant = newToolbarHeight;
+        self.toolbarHeightConstraint.constant = newToolbarHeight + bottomPadding;
     }];
 }
 

--- a/JSQMessagesViewController/Views/MEGAInputToolbar.m
+++ b/JSQMessagesViewController/Views/MEGAInputToolbar.m
@@ -91,15 +91,6 @@ static NSString * const kMEGAUIKeyInputCarriageReturn = @"\r";
     }
 }
 
-- (void)didMoveToWindow {
-    [super didMoveToWindow];
-    if (@available(iOS 11.0, *)) {
-        if (self.window.safeAreaLayoutGuide != nil) {
-            [[self bottomAnchor] constraintLessThanOrEqualToSystemSpacingBelowAnchor:self.window.safeAreaLayoutGuide.bottomAnchor multiplier:1.0].active = YES;
-        }
-    }
-}
-
 - (void)loadToolbarTextContentView {
     NSArray *nibViews = [[NSBundle bundleForClass:[MEGAToolbarContentView class]] loadNibNamed:@"MEGAToolbarTextContentView"
                                                                                          owner:nil


### PR DESCRIPTION
Problem: Adding the constraint in `didMoveToWindow` method of `MEGAInputToolbar` does not seem to work in iOS 13. 

Solution:  Increase the height of toolbar as the subviews consider the safe area layout into consideration.