### PR TITLE
#13280: Reverting the [90fed75] commit - 13.0 fix as the issue is fixed in iOS 13.1

### DIFF
--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
@@ -774,14 +774,8 @@ extern const CGFloat kTextContentViewHeight;
 }
 
 - (void)messagesInputToolbar:(MEGAInputToolbar *)toolbar needsResizeToHeight:(CGFloat)newToolbarHeight {
-    CGFloat bottomPadding = 0;
-    if (@available(iOS 11.0, *)) {
-        UIWindow *window = UIApplication.sharedApplication.keyWindow;
-        bottomPadding = window.safeAreaInsets.bottom;
-    }
-    
     [UIView animateWithDuration:0.3 animations:^{
-        self.toolbarHeightConstraint.constant = newToolbarHeight + bottomPadding;
+        self.toolbarHeightConstraint.constant = newToolbarHeight;
     }];
 }
 

--- a/JSQMessagesViewController/Views/MEGAInputToolbar.m
+++ b/JSQMessagesViewController/Views/MEGAInputToolbar.m
@@ -91,6 +91,15 @@ static NSString * const kMEGAUIKeyInputCarriageReturn = @"\r";
     }
 }
 
+- (void)didMoveToWindow {
+    [super didMoveToWindow];
+    if (@available(iOS 11.0, *)) {
+        if (self.window.safeAreaLayoutGuide != nil) {
+            [[self bottomAnchor] constraintLessThanOrEqualToSystemSpacingBelowAnchor:self.window.safeAreaLayoutGuide.bottomAnchor multiplier:1.0].active = YES;
+        }
+    }
+}
+
 - (void)loadToolbarTextContentView {
     NSArray *nibViews = [[NSBundle bundleForClass:[MEGAToolbarContentView class]] loadNibNamed:@"MEGAToolbarTextContentView"
                                                                                          owner:nil


### PR DESCRIPTION
#13280: iOS 13.0: Chat Screen: Tapping on textfield (Bottom of the screen) does not show up the keyboard.
---------------

Reverting the 13.0 fix (commit id 90fed75db3b4574acf302c998ec4c5d9ec051172) as the issue is resolved by Apple in 13.1