### PR TITLE
#13300: Chat message is clipped

### DIFF
--- a/JSQMessagesViewController/Layout/JSQMessagesBubblesSizeCalculator.m
+++ b/JSQMessagesViewController/Layout/JSQMessagesBubblesSizeCalculator.m
@@ -27,6 +27,7 @@
 
 #import "MEGAChatMessage+MNZCategory.h"
 #import "NSString+MNZCategory.h"
+@import CoreText;
 
 @interface JSQMessagesBubblesSizeCalculator ()
 
@@ -139,9 +140,12 @@
                                                           context:nil];
         } else if (((MEGAChatMessage *)messageData).attributedText.length > 0) {
             NSAttributedString *attributedString = ((MEGAChatMessage *)messageData).attributedText;
-            stringRect = [attributedString boundingRectWithSize:CGSizeMake(maximumTextWidth, CGFLOAT_MAX)
-                                                        options:(NSStringDrawingUsesLineFragmentOrigin | NSStringDrawingUsesFontLeading)
-                                                        context:nil];
+
+            CTFramesetterRef framesetter = CTFramesetterCreateWithAttributedString( (CFAttributedStringRef)attributedString);
+            CGSize size = CTFramesetterSuggestFrameSizeWithConstraints(framesetter, CFRangeMake(0, 0), nil, CGSizeMake(maximumTextWidth, CGFLOAT_MAX), nil);
+            
+            stringRect = CGRectMake(0, 0, ceil(size.width), ceil(size.height));
+            CFRelease(framesetter);
         } else {
             stringRect = [[messageData text] boundingRectWithSize:CGSizeMake(maximumTextWidth, CGFLOAT_MAX)
                                                           options:(NSStringDrawingUsesLineFragmentOrigin | NSStringDrawingUsesFontLeading)


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
`boundingRectWithSize` gives lesser height for the font we are using. Hence using core text framework methods to fix this issue.

### Before:

| Before        |  After | 
| ------------- |:-------------:| 
| <img src="https://user-images.githubusercontent.com/53881615/66537635-a39e2300-eb7d-11e9-8fd9-8d1b9254cd3a.jpeg" width=320> | <img src="https://user-images.githubusercontent.com/53881615/66537636-a39e2300-eb7d-11e9-94a7-467bcc9d38a1.jpeg" width=320> |

## Does this close any currently open issues?
#13300

## Where has this been tested?
Devices/Simulators: iPhone XS
iOS Version: 13.1.2




