### PR TITLE
#13353: Setting the audio category to Record while recording the clip…

### DIFF
--- a/JSQMessagesViewController/Views/MEGAInputToolbar.m
+++ b/JSQMessagesViewController/Views/MEGAInputToolbar.m
@@ -389,10 +389,6 @@ static NSString * const kMEGAUIKeyInputCarriageReturn = @"\r";
 
 - (BOOL)startRecordingAudio {
     NSError *error;
-    if (![[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryRecord error:&error]) {
-        MEGALogError(@"[Voice clips] Error setting the category to AVAudioSessionCategoryRecord: %@", error);
-        return [self handleAVAudioSessionError:error];
-    }
 
     if (![[AVAudioSession sharedInstance] setActive:YES error:&error]) {
         MEGALogError(@"[Voice clips] Error activating audio session: %@", error);

--- a/JSQMessagesViewController/Views/MEGAInputToolbar.m
+++ b/JSQMessagesViewController/Views/MEGAInputToolbar.m
@@ -390,6 +390,10 @@ static NSString * const kMEGAUIKeyInputCarriageReturn = @"\r";
 - (BOOL)startRecordingAudio {
     NSError *error;
 
+    if (![AVAudioSession.sharedInstance setMode:AVAudioSessionModeDefault error:&error]) {
+        MEGALogError(@"[Voice clips] Error setting default mode: %@", error);
+    }
+    
     if (![[AVAudioSession sharedInstance] setActive:YES error:&error]) {
         MEGALogError(@"[Voice clips] Error activating audio session: %@", error);
         return [self handleAVAudioSessionError:error];
@@ -432,6 +436,10 @@ static NSString * const kMEGAUIKeyInputCarriageReturn = @"\r";
     self.audioRecorder = nil;
     
     NSError *error;
+    if (![AVAudioSession.sharedInstance setMode:AVAudioSessionModeVoiceChat error:&error]) {
+        MEGALogError(@"[Voice clips] Error setting voice chat mode: %@", error);
+    }
+    
     if (![[AVAudioSession sharedInstance] setActive:NO withOptions:AVAudioSessionSetActiveOptionNotifyOthersOnDeactivation error:&error]) {
         MEGALogError(@"[Voice clips] Error deactivating audio session: %@", error);
     }

--- a/JSQMessagesViewController/Views/MEGAInputToolbar.m
+++ b/JSQMessagesViewController/Views/MEGAInputToolbar.m
@@ -756,7 +756,7 @@ static NSString * const kMEGAUIKeyInputCarriageReturn = @"\r";
             break;
             
         default:
-            errorMessage = [NSString stringWithFormat:@"Error recording voice message: %td", errorCode];
+            errorMessage = error.localizedDescription;
             break;
     }
     [SVProgressHUD showErrorWithStatus:errorMessage];


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
--------------------------------------------------
For some reason audio was not audible once I get the Video call and installed the new TestFlight build.

Setting the Audio session category to AVAudioSessionCategoryPlayback.

Does this close any currently open issues?
------------------------------------------
#13353

Where has this been tested?
---------------------------
**Devices/Simulators:** iPhone XS Max

**iOS Version:**: 13.1.2