### PR TITLE
#13092 : Orientation change fix causing issue in iPhone 6 (Non safe area devices)

### DIFF
--- a/JSQMessagesViewController/Views/MEGAInputToolbar.m
+++ b/JSQMessagesViewController/Views/MEGAInputToolbar.m
@@ -79,8 +79,6 @@ static NSString * const kMEGAUIKeyInputCarriageReturn = @"\r";
                                                          self.contentView.textView.frame.origin.y,
                                                          newTextViewWidth,
                                                          self.contentView.textView.frame.size.height);
-        } else {
-            self.imagePickerView.frame = self.frame = CGRectMake(0.0f, 0.0f, [UIScreen mainScreen].bounds.size.width, kImagePickerViewHeight);
         }
     }
     // Scroll to bottom of the text view:


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.

1) when the orientation is changed from portrait to landscape, `[UIScreen mainScreen].bounds.size.width` in `layoutSubviews` returns the width in portrait rather than landscape .
2) Autoresizing mask is already set in storyboard. I think we don't need to change the frame as autoresizing makes sure the content view fills the superview.

### Before:

| Before       |  After           | 
| ------------- |:-------------:| 
| <img src="https://user-images.githubusercontent.com/53881615/66723245-4bb03680-ee73-11e9-8cf3-3d6dbcc3af00.png" width=320> | <img src="https://user-images.githubusercontent.com/53881615/66723246-4c48cd00-ee73-11e9-86b4-fa966f5a71b2.png" width=320> |


## Does this close any currently open issues?
#13092

## Where has this been tested?
Devices/Simulators: iPhone 7, iPhone XS, iPhone 8 (Simulator)
iOS Version: 13.1.2, 12.2 






