### PR TITLE
fix The system crashing when long press on a MEGA public link in chat…

### DIFF
--- a/JSQMessagesViewController/Views/JSQMessagesCellTextView.m
+++ b/JSQMessagesViewController/Views/JSQMessagesCellTextView.m
@@ -111,19 +111,33 @@
 #pragma mark - UITextViewDelegate
 
 - (BOOL)textView:(UITextView *)textView shouldInteractWithURL:(NSURL *)URL inRange:(NSRange)characterRange interaction:(UITextItemInteraction)interaction {
-    BOOL shouldInteract = YES;
+    
+    BOOL recognizedTapGesture = NO;
+    for (UIGestureRecognizer *recognizer in textView.gestureRecognizers) {
+        if ([recognizer isKindOfClass:UITapGestureRecognizer.class] && recognizer.state == UIGestureRecognizerStateEnded) {
+            recognizedTapGesture = YES;
+            break;
+        }
+    }
+    if (!recognizedTapGesture) {
+        // Tap gesture is not being recognized, this must be an early
+        // check when touches begin. Leave the link handling alone.
+        return YES;
+    }
+
+    // Do custom action here
     switch (interaction) {
         case UITextItemInteractionInvokeDefaultAction:
             MEGALinkManager.linkURL = URL;
             [MEGALinkManager processLinkURL:URL];
-            shouldInteract = NO;
             break;
             
         default:
             break;
     }
     
-    return shouldInteract;
+    return NO;
+    
 }
 
 @end


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
Chat - The system crashing when long press on a MEGA public link in a chat room

reference: [iOS 13.1 UITextView delegate method shouldInteract called when scrolling on attachment](https://stackoverflow.com/questions/58189447/ios-13-1-uitextview-delegate-method-shouldinteract-called-when-scrolling-on-atta)
## Does this close any currently open issues?
#[13359](https://issues.developers.mega.co.nz/issues/13359)

## Where has this been tested?
Devices/Simulators: iPhone 8
iOS Version: 13.1




