### PR TITLE
Expandable chat toolbar

### DIFF
--- a/JSQMessagesViewController/Views/MEGAInputToolbar.m
+++ b/JSQMessagesViewController/Views/MEGAInputToolbar.m
@@ -204,6 +204,10 @@ typedef NS_ENUM(NSUInteger, InputToolbarMode) {
 }
 
 - (void)mnz_accesoryButtonPressed:(UIButton *)sender {
+    if (self.currentMode == InputToolbarModeExpanded) {
+        [self mnz_expandOrCollapseButtonPressed];
+    }
+    
     switch (sender.tag) {
         case MEGAChatAccessoryButtonText:
             if (self.imagePickerView) {
@@ -607,10 +611,8 @@ typedef NS_ENUM(NSUInteger, InputToolbarMode) {
 
 - (void)resizeToolbarIfNeeded {
     CGFloat newToolbarHeight = [self heightToFitInWidth:self.contentView.textView.frame.size.width];
-    [UIView animateWithDuration:0.3 animations:^{
-        self.contentView.contentViewHeightConstraint.constant = newToolbarHeight;
-        [self.contentView layoutIfNeeded];
-    }];
+    self.contentView.contentViewHeightConstraint.constant = newToolbarHeight;
+    [self.contentView layoutIfNeeded];
     [self.delegate messagesInputToolbar:self needsResizeToHeight:newToolbarHeight];
 }
 

--- a/JSQMessagesViewController/Views/MEGAInputToolbar.m
+++ b/JSQMessagesViewController/Views/MEGAInputToolbar.m
@@ -482,6 +482,7 @@ static NSString * const kMEGAUIKeyInputCarriageReturn = @"\r";
         case InputToolbarStateWriting: {
             UIImage *sendButton = [UIImage imageNamed:@"sendButton"];
             [self.contentView.sendButton setImage:sendButton.imageFlippedForRightToLeftLayoutDirection forState:UIControlStateNormal];
+            self.contentView.sendButton.enabled = self.contentView.textView.hasText;
             self.contentView.recordingContainerView.hidden = self.contentView.slideToCancelButton.hidden = self.contentView.lockView.hidden = YES;
             
             break;
@@ -576,7 +577,7 @@ static NSString * const kMEGAUIKeyInputCarriageReturn = @"\r";
         return;
     }
     
-    self.currentState = [self.contentView.textView hasText] ? InputToolbarStateWriting : InputToolbarStateInitial;
+    self.currentState = self.contentView.textView.text.length ? InputToolbarStateWriting : InputToolbarStateInitial;
     [self updateToolbar];
     [self resizeToolbarIfNeeded];
 }

--- a/JSQMessagesViewController/Views/MEGAInputToolbar.m
+++ b/JSQMessagesViewController/Views/MEGAInputToolbar.m
@@ -15,7 +15,7 @@ extern const CGFloat kCellSquareSize;
 extern const CGFloat kCellInset;
 extern const NSUInteger kCellRows;
 const CGFloat kButtonBarHeight = 50.0f;
-const CGFloat kTextContentViewHeight = 80.0f;
+const CGFloat kTextContentViewHeight = 86.0f;
 const CGFloat kSelectedAssetsViewHeight = 200.0f;
 const CGFloat kTextViewHorizontalMargins = 34.0f;
 const CGFloat kMinimunRecordDuration = 1.0f;
@@ -588,8 +588,10 @@ static NSString * const kMEGAUIKeyInputCarriageReturn = @"\r";
 }
 
 - (CGFloat)heightToFitInWidth:(CGFloat)width {
-    CGFloat originalTextViewHeight = 20.0f;
-    CGFloat maxTextViewHeight = 50.0f;
+    CGFloat lineHeight = 18.0f;
+    NSUInteger maxLinesWhenCollapsed = 5;
+    CGFloat originalTextViewHeight = 2.0f + lineHeight;
+    CGFloat maxTextViewHeight = maxLinesWhenCollapsed * lineHeight;
     CGSize sizeThatFits = [self.contentView.textView sizeThatFits:CGSizeMake(width, self.contentView.textView.frame.size.height)];
     CGFloat textViewHeightNeeded = sizeThatFits.height;
     textViewHeightNeeded = textViewHeightNeeded > maxTextViewHeight ? maxTextViewHeight : textViewHeightNeeded;

--- a/JSQMessagesViewController/Views/MEGAInputToolbar.m
+++ b/JSQMessagesViewController/Views/MEGAInputToolbar.m
@@ -551,6 +551,7 @@ typedef NS_ENUM(NSUInteger, InputToolbarMode) {
             UIImage *collapseImage = [UIImage imageNamed:@"collapse"];
             [self.contentView.expandOrCollapseButton setImage:collapseImage.imageFlippedForRightToLeftLayoutDirection forState:UIControlStateNormal];
             self.contentView.draggableViewHeightConstraint.constant = 45.0f;
+            self.contentView.opaqueContentView.layer.cornerRadius = 13.0f;
         } else {
             [self.contentView.textView becomeFirstResponder];
         }
@@ -559,6 +560,7 @@ typedef NS_ENUM(NSUInteger, InputToolbarMode) {
         UIImage *expandImage = [UIImage imageNamed:@"expand"];
         [self.contentView.expandOrCollapseButton setImage:expandImage.imageFlippedForRightToLeftLayoutDirection forState:UIControlStateNormal];
         self.contentView.draggableViewHeightConstraint.constant = 0.0f;
+        self.contentView.opaqueContentView.layer.cornerRadius = 0.0f;
     }
     
     [self resizeToolbarIfNeeded];

--- a/JSQMessagesViewController/Views/MEGAInputToolbar.m
+++ b/JSQMessagesViewController/Views/MEGAInputToolbar.m
@@ -552,6 +552,7 @@ typedef NS_ENUM(NSUInteger, InputToolbarMode) {
             [self.contentView.expandOrCollapseButton setImage:collapseImage.imageFlippedForRightToLeftLayoutDirection forState:UIControlStateNormal];
             self.contentView.draggableViewHeightConstraint.constant = 45.0f;
             self.contentView.opaqueContentView.layer.cornerRadius = 13.0f;
+            self.contentView.shadowContentView.hidden = NO;
         } else {
             [self.contentView.textView becomeFirstResponder];
         }
@@ -561,6 +562,7 @@ typedef NS_ENUM(NSUInteger, InputToolbarMode) {
         [self.contentView.expandOrCollapseButton setImage:expandImage.imageFlippedForRightToLeftLayoutDirection forState:UIControlStateNormal];
         self.contentView.draggableViewHeightConstraint.constant = 0.0f;
         self.contentView.opaqueContentView.layer.cornerRadius = 0.0f;
+        self.contentView.shadowContentView.hidden = YES;
     }
     
     [self resizeToolbarIfNeeded];

--- a/JSQMessagesViewController/Views/MEGAToolbarContentView.h
+++ b/JSQMessagesViewController/Views/MEGAToolbarContentView.h
@@ -49,6 +49,7 @@ typedef NS_ENUM(NSUInteger, MEGAChatAccessoryButton) {
 @property (weak, nonatomic) IBOutlet UIView *garbageView;
 @property (weak, nonatomic) IBOutlet UIButton *recordButton;
 @property (weak, nonatomic) IBOutlet UIButton *expandOrCollapseButton;
-@property (weak, nonatomic) IBOutlet NSLayoutConstraint *textViewToTopConstraint;
+@property (weak, nonatomic) IBOutlet UIView *draggableView;
+@property (weak, nonatomic) IBOutlet NSLayoutConstraint *draggableViewHeightConstraint;
 
 @end

--- a/JSQMessagesViewController/Views/MEGAToolbarContentView.h
+++ b/JSQMessagesViewController/Views/MEGAToolbarContentView.h
@@ -40,7 +40,6 @@ typedef NS_ENUM(NSUInteger, MEGAChatAccessoryButton) {
 @property (weak, nonatomic) IBOutlet UIButton *accessoryImageButton;
 @property (weak, nonatomic) IBOutlet UIButton *accessoryUploadButton;
 
-@property (weak, nonatomic) IBOutlet UIView *recordingView;
 @property (weak, nonatomic) IBOutlet UILabel *recordingTimeLabel;
 @property (weak, nonatomic) IBOutlet UIButton *slideToCancelButton;
 @property (weak, nonatomic) IBOutlet UIView *lockView;
@@ -49,5 +48,7 @@ typedef NS_ENUM(NSUInteger, MEGAChatAccessoryButton) {
 @property (weak, nonatomic) IBOutlet UIImageView *headerGarbageView;
 @property (weak, nonatomic) IBOutlet UIView *garbageView;
 @property (weak, nonatomic) IBOutlet UIButton *recordButton;
+@property (weak, nonatomic) IBOutlet UIButton *expandOrCollapseButton;
+@property (weak, nonatomic) IBOutlet NSLayoutConstraint *textViewToTopConstraint;
 
 @end

--- a/JSQMessagesViewController/Views/MEGAToolbarContentView.h
+++ b/JSQMessagesViewController/Views/MEGAToolbarContentView.h
@@ -30,6 +30,7 @@ typedef NS_ENUM(NSUInteger, MEGAChatAccessoryButton) {
 @property (weak, nonatomic) IBOutlet UICollectionView *collectionView;
 @property (weak, nonatomic) IBOutlet UICollectionView *selectedAssetsCollectionView;
 @property (weak, nonatomic) IBOutlet UIView *opaqueContentView;
+@property (weak, nonatomic) IBOutlet UIView *shadowContentView;
 
 /**
  *  The button to send messages, displayed on the right of the toolbar content view.

--- a/JSQMessagesViewController/Views/MEGAToolbarTextContentView.xib
+++ b/JSQMessagesViewController/Views/MEGAToolbarTextContentView.xib
@@ -115,7 +115,7 @@
                                     <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                 </textView>
                                 <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vfR-cz-NSL">
-                                    <rect key="frame" x="130.5" y="10" width="114" height="30"/>
+                                    <rect key="frame" x="130.5" y="16" width="114" height="30"/>
                                     <state key="normal" title="&lt; Slide to cancel">
                                         <color key="titleColor" red="0.40000000000000002" green="0.40000000000000002" blue="0.40000000000000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </state>
@@ -131,7 +131,7 @@
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BXC-LX-Ht2">
-                                            <rect key="frame" x="22" y="79" width="18" height="32"/>
+                                            <rect key="frame" x="22" y="85" width="18" height="26"/>
                                             <subviews>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" image="bucketLid" translatesAutoresizingMaskIntoConstraints="NO" id="ChV-AM-4dZ">
                                                     <rect key="frame" x="0.0" y="0.0" width="18" height="4"/>
@@ -145,7 +145,7 @@
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         </view>
                                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="G3E-zc-1V4">
-                                            <rect key="frame" x="16" y="11" width="30" height="30"/>
+                                            <rect key="frame" x="16" y="17" width="30" height="30"/>
                                             <state key="normal" image="sendVoiceClipActive"/>
                                         </button>
                                     </subviews>
@@ -157,14 +157,14 @@
                                         <constraint firstAttribute="bottom" secondItem="uJd-TE-hLU" secondAttribute="bottom" id="9me-z9-BIs"/>
                                         <constraint firstItem="G3E-zc-1V4" firstAttribute="leading" secondItem="PCQ-dy-pUZ" secondAttribute="leading" constant="16" id="OU4-6t-BdF"/>
                                         <constraint firstItem="BXC-LX-Ht2" firstAttribute="bottom" secondItem="uJd-TE-hLU" secondAttribute="bottom" constant="69" id="PWI-Ry-vnG"/>
-                                        <constraint firstItem="BXC-LX-Ht2" firstAttribute="top" secondItem="PCQ-dy-pUZ" secondAttribute="top" constant="79" id="Yn5-pW-eyx"/>
+                                        <constraint firstItem="BXC-LX-Ht2" firstAttribute="top" secondItem="PCQ-dy-pUZ" secondAttribute="top" constant="85" id="Yn5-pW-eyx"/>
                                         <constraint firstAttribute="trailing" secondItem="BXC-LX-Ht2" secondAttribute="trailing" constant="52" id="cJm-h8-6U0"/>
                                         <constraint firstItem="BXC-LX-Ht2" firstAttribute="leading" secondItem="PCQ-dy-pUZ" secondAttribute="leading" constant="22" id="l3r-or-WkE"/>
-                                        <constraint firstItem="G3E-zc-1V4" firstAttribute="top" secondItem="PCQ-dy-pUZ" secondAttribute="top" constant="11" id="neU-0h-xDF"/>
+                                        <constraint firstItem="G3E-zc-1V4" firstAttribute="top" secondItem="PCQ-dy-pUZ" secondAttribute="top" constant="17" id="neU-0h-xDF"/>
                                     </constraints>
                                 </view>
                                 <button contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yqt-18-HR0">
-                                    <rect key="frame" x="319" y="10" width="50" height="30"/>
+                                    <rect key="frame" x="319" y="16" width="50" height="30"/>
                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     <fontDescription key="fontDescription" name="SFUIText-Semibold" family="SF UI Text" pointSize="12"/>
                                     <inset key="contentEdgeInsets" minX="10" minY="0.0" maxX="10" maxY="0.0"/>
@@ -200,6 +200,7 @@
                                 <constraint firstItem="Q9K-U3-wwY" firstAttribute="top" secondItem="PCQ-dy-pUZ" secondAttribute="bottom" constant="4" id="6XL-HD-4yp"/>
                                 <constraint firstAttribute="trailing" secondItem="yqt-18-HR0" secondAttribute="trailing" constant="6" id="7y7-jb-7gy"/>
                                 <constraint firstAttribute="bottom" secondItem="fDU-tM-mKk" secondAttribute="bottom" constant="9" id="Dva-Hg-ioB"/>
+                                <constraint firstAttribute="bottom" secondItem="yqt-18-HR0" secondAttribute="bottom" constant="39" id="KeK-Ua-trg"/>
                                 <constraint firstAttribute="height" constant="85" id="MlO-Yr-7I8"/>
                                 <constraint firstItem="PCQ-dy-pUZ" firstAttribute="leading" secondItem="7c7-YZ-oiz" secondAttribute="leading" id="OA3-fw-Jui"/>
                                 <constraint firstItem="vfR-cz-NSL" firstAttribute="centerY" secondItem="yqt-18-HR0" secondAttribute="centerY" id="OgQ-aB-xBy"/>
@@ -211,7 +212,6 @@
                                 <constraint firstItem="Q9K-U3-wwY" firstAttribute="leading" secondItem="7c7-YZ-oiz" secondAttribute="leading" constant="16" id="jxc-el-ttc"/>
                                 <constraint firstItem="fDU-tM-mKk" firstAttribute="leading" secondItem="Q9K-U3-wwY" secondAttribute="trailing" constant="16" id="kj9-s9-rNQ"/>
                                 <constraint firstItem="PCQ-dy-pUZ" firstAttribute="top" secondItem="7c7-YZ-oiz" secondAttribute="top" id="neP-Yt-umR"/>
-                                <constraint firstItem="yqt-18-HR0" firstAttribute="top" secondItem="7c7-YZ-oiz" secondAttribute="top" constant="10" id="rnv-Dy-O6D"/>
                                 <constraint firstItem="Mas-Ji-t8P" firstAttribute="leading" secondItem="fDU-tM-mKk" secondAttribute="trailing" constant="16" id="vKJ-U6-uli"/>
                             </constraints>
                         </view>

--- a/JSQMessagesViewController/Views/MEGAToolbarTextContentView.xib
+++ b/JSQMessagesViewController/Views/MEGAToolbarTextContentView.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -204,10 +204,10 @@
                                     <state key="normal" image="button_upload_default"/>
                                 </button>
                                 <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="y5I-6X-wKb">
-                                    <rect key="frame" x="331" y="16" width="28" height="28"/>
+                                    <rect key="frame" x="329" y="16" width="30" height="30"/>
                                     <constraints>
-                                        <constraint firstAttribute="height" constant="28" id="R7C-xK-2aW"/>
-                                        <constraint firstAttribute="width" constant="28" id="ous-aU-yUa"/>
+                                        <constraint firstAttribute="height" constant="30" id="R7C-xK-2aW"/>
+                                        <constraint firstAttribute="width" constant="30" id="ous-aU-yUa"/>
                                     </constraints>
                                     <state key="normal" title="Button" image="expand"/>
                                 </button>

--- a/JSQMessagesViewController/Views/MEGAToolbarTextContentView.xib
+++ b/JSQMessagesViewController/Views/MEGAToolbarTextContentView.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15509"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -103,6 +103,10 @@
                                 <constraint firstItem="iOF-Cw-q0K" firstAttribute="centerX" secondItem="p69-k2-jfV" secondAttribute="centerX" id="vjx-jE-NIK"/>
                             </constraints>
                             <viewLayoutGuide key="safeArea" id="gWN-Og-zg2"/>
+                        </view>
+                        <view hidden="YES" alpha="0.40000000000000002" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="To9-SW-Fam">
+                            <rect key="frame" x="0.0" y="-50" width="375" height="180"/>
+                            <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7c7-YZ-oiz">
                             <rect key="frame" x="0.0" y="75" width="375" height="85"/>
@@ -239,19 +243,23 @@
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <constraints>
                         <constraint firstItem="BfD-Cm-wk4" firstAttribute="top" secondItem="J7o-7B-4nA" secondAttribute="bottom" id="0iV-HF-dre"/>
+                        <constraint firstItem="To9-SW-Fam" firstAttribute="trailing" secondItem="lzz-Kj-bhf" secondAttribute="trailing" id="5Wh-NQ-zcI"/>
                         <constraint firstItem="p69-k2-jfV" firstAttribute="top" secondItem="BfD-Cm-wk4" secondAttribute="bottom" id="8I1-gw-2Js"/>
                         <constraint firstAttribute="bottom" secondItem="p69-k2-jfV" secondAttribute="bottom" id="Amv-13-Xbs"/>
                         <constraint firstItem="BWP-qA-B0h" firstAttribute="centerX" secondItem="yqt-18-HR0" secondAttribute="centerX" id="B1n-wF-saU"/>
                         <constraint firstItem="p69-k2-jfV" firstAttribute="height" secondItem="7c7-YZ-oiz" secondAttribute="height" id="FCQ-kK-0BO"/>
                         <constraint firstItem="7c7-YZ-oiz" firstAttribute="top" secondItem="BfD-Cm-wk4" secondAttribute="bottom" id="Gak-m2-Zbz"/>
                         <constraint firstAttribute="bottom" secondItem="7c7-YZ-oiz" secondAttribute="bottom" id="IyM-0H-hAh"/>
+                        <constraint firstItem="To9-SW-Fam" firstAttribute="bottom" secondItem="7c7-YZ-oiz" secondAttribute="bottom" constant="-30" id="JAt-hG-t6L"/>
                         <constraint firstItem="J7o-7B-4nA" firstAttribute="trailing" secondItem="Ah5-Zw-hJJ" secondAttribute="trailing" id="K58-qR-cmy"/>
                         <constraint firstItem="7c7-YZ-oiz" firstAttribute="leading" secondItem="lzz-Kj-bhf" secondAttribute="leading" id="MH4-YZ-twZ"/>
                         <constraint firstItem="p69-k2-jfV" firstAttribute="leading" secondItem="lzz-Kj-bhf" secondAttribute="leading" id="MOh-ck-X6s"/>
                         <constraint firstItem="J7o-7B-4nA" firstAttribute="leading" secondItem="Ah5-Zw-hJJ" secondAttribute="leading" id="R8t-ua-OdL"/>
                         <constraint firstAttribute="trailing" secondItem="7c7-YZ-oiz" secondAttribute="trailing" id="fGQ-p8-fBb"/>
                         <constraint firstAttribute="trailing" secondItem="BfD-Cm-wk4" secondAttribute="trailing" id="k84-uE-3EI"/>
+                        <constraint firstItem="To9-SW-Fam" firstAttribute="leading" secondItem="lzz-Kj-bhf" secondAttribute="leading" id="rOg-if-LAB"/>
                         <constraint firstItem="BWP-qA-B0h" firstAttribute="bottom" secondItem="lzz-Kj-bhf" secondAttribute="bottom" id="vUx-sY-yBH"/>
+                        <constraint firstItem="To9-SW-Fam" firstAttribute="top" secondItem="Ah5-Zw-hJJ" secondAttribute="top" constant="-50" id="wP7-pK-tta"/>
                         <constraint firstItem="p69-k2-jfV" firstAttribute="trailing" secondItem="lzz-Kj-bhf" secondAttribute="trailing" id="xGQ-cI-xoD"/>
                         <constraint firstItem="BfD-Cm-wk4" firstAttribute="leading" secondItem="lzz-Kj-bhf" secondAttribute="leading" id="z0V-eb-C8Z"/>
                     </constraints>
@@ -286,6 +294,7 @@
                 <outlet property="recordingContainerView" destination="PCQ-dy-pUZ" id="MCo-Oi-Qce"/>
                 <outlet property="recordingTimeLabel" destination="uJd-TE-hLU" id="T0n-H0-ist"/>
                 <outlet property="sendButton" destination="yqt-18-HR0" id="5gS-04-8WK"/>
+                <outlet property="shadowContentView" destination="To9-SW-Fam" id="Jph-sb-yW7"/>
                 <outlet property="slideToCancelButton" destination="vfR-cz-NSL" id="Khj-Ka-VPj"/>
                 <outlet property="textView" destination="FzB-DF-mS3" id="4Lm-7E-qbM"/>
                 <outlet property="typingIndicatorLabel" destination="hZu-NL-NtO" id="Rx8-um-gIc"/>

--- a/JSQMessagesViewController/Views/MEGAToolbarTextContentView.xib
+++ b/JSQMessagesViewController/Views/MEGAToolbarTextContentView.xib
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15509"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -21,11 +19,11 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="MEGAToolbarContentView">
-            <rect key="frame" x="0.0" y="0.0" width="375" height="154"/>
+            <rect key="frame" x="0.0" y="0.0" width="375" height="160"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lzz-Kj-bhf">
-                    <rect key="frame" x="0.0" y="0.0" width="375" height="154"/>
+                    <rect key="frame" x="0.0" y="0.0" width="375" height="160"/>
                     <subviews>
                         <visualEffectView hidden="YES" opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="J7o-7B-4nA">
                             <rect key="frame" x="0.0" y="50" width="375" height="24"/>
@@ -60,7 +58,7 @@
                             </constraints>
                         </view>
                         <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BWP-qA-B0h">
-                            <rect key="frame" x="321" y="0.0" width="46" height="154"/>
+                            <rect key="frame" x="321" y="0.0" width="46" height="160"/>
                             <subviews>
                                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="lockRecording" translatesAutoresizingMaskIntoConstraints="NO" id="ID7-4I-ZL3">
                                     <rect key="frame" x="8" y="16" width="30" height="30"/>
@@ -70,7 +68,7 @@
                             <constraints>
                                 <constraint firstItem="ID7-4I-ZL3" firstAttribute="centerX" secondItem="BWP-qA-B0h" secondAttribute="centerX" id="Gih-NI-NwH"/>
                                 <constraint firstItem="ID7-4I-ZL3" firstAttribute="top" secondItem="BWP-qA-B0h" secondAttribute="top" constant="16" id="KM7-ZL-EIo"/>
-                                <constraint firstAttribute="height" constant="154" id="aKr-dH-VJ9"/>
+                                <constraint firstAttribute="height" constant="160" id="aKr-dH-VJ9"/>
                                 <constraint firstAttribute="width" constant="46" id="bEB-EH-uzb"/>
                             </constraints>
                             <userDefinedRuntimeAttributes>
@@ -80,10 +78,10 @@
                             </userDefinedRuntimeAttributes>
                         </view>
                         <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="p69-k2-jfV">
-                            <rect key="frame" x="0.0" y="75" width="375" height="79"/>
+                            <rect key="frame" x="0.0" y="75" width="375" height="85"/>
                             <subviews>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="iOF-Cw-q0K">
-                                    <rect key="frame" x="43.5" y="14.5" width="288" height="50"/>
+                                    <rect key="frame" x="43.5" y="17.5" width="288" height="50"/>
                                     <color key="backgroundColor" red="0.95294117649999999" green="0.047058823530000002" blue="0.078431372550000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     <constraints>
                                         <constraint firstAttribute="width" constant="288" id="Nme-ey-THr"/>
@@ -107,10 +105,10 @@
                             <viewLayoutGuide key="safeArea" id="gWN-Og-zg2"/>
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7c7-YZ-oiz">
-                            <rect key="frame" x="0.0" y="75" width="375" height="79"/>
+                            <rect key="frame" x="0.0" y="75" width="375" height="85"/>
                             <subviews>
                                 <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="FzB-DF-mS3" customClass="JSQMessagesComposerTextView">
-                                    <rect key="frame" x="16" y="10" width="297" height="20"/>
+                                    <rect key="frame" x="16" y="16" width="297" height="20"/>
                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     <color key="textColor" red="0.20000000000000001" green="0.20000000000000001" blue="0.20000000000000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     <fontDescription key="fontDescription" name="SFUIText-Regular" family="SF UI Text" pointSize="15"/>
@@ -123,17 +121,17 @@
                                     </state>
                                 </button>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="PCQ-dy-pUZ">
-                                    <rect key="frame" x="0.0" y="0.0" width="92" height="36"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="92" height="42"/>
                                     <subviews>
                                         <label userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="00:00" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uJd-TE-hLU">
-                                            <rect key="frame" x="49" y="15" width="46" height="21"/>
+                                            <rect key="frame" x="49" y="21" width="46" height="21"/>
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BXC-LX-Ht2">
-                                            <rect key="frame" x="22" y="79" width="18" height="26"/>
+                                            <rect key="frame" x="22" y="79" width="18" height="32"/>
                                             <subviews>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" image="bucketLid" translatesAutoresizingMaskIntoConstraints="NO" id="ChV-AM-4dZ">
                                                     <rect key="frame" x="0.0" y="0.0" width="18" height="4"/>
@@ -180,17 +178,17 @@
                                     </userDefinedRuntimeAttributes>
                                 </button>
                                 <button opaque="NO" tag="11" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Q9K-U3-wwY" userLabel="Camera">
-                                    <rect key="frame" x="16" y="40" width="30" height="30"/>
+                                    <rect key="frame" x="16" y="46" width="30" height="30"/>
                                     <color key="tintColor" red="0.59999999999999998" green="0.59999999999999998" blue="0.59999999999999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     <state key="normal" image="button_camera_default"/>
                                 </button>
                                 <button opaque="NO" tag="12" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fDU-tM-mKk" userLabel="Media">
-                                    <rect key="frame" x="62" y="40" width="30" height="30"/>
+                                    <rect key="frame" x="62" y="46" width="30" height="30"/>
                                     <color key="tintColor" red="0.59999999999999998" green="0.59999999999999998" blue="0.59999999999999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     <state key="normal" image="button_media_default"/>
                                 </button>
                                 <button opaque="NO" tag="13" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Mas-Ji-t8P" userLabel="Upload">
-                                    <rect key="frame" x="108" y="40" width="30" height="30"/>
+                                    <rect key="frame" x="108" y="46" width="30" height="30"/>
                                     <color key="tintColor" red="0.59215686274509804" green="0.59215686274509804" blue="0.59215686274509804" alpha="1" colorSpace="calibratedRGB"/>
                                     <state key="normal" image="button_upload_default"/>
                                 </button>
@@ -202,11 +200,11 @@
                                 <constraint firstItem="Q9K-U3-wwY" firstAttribute="top" secondItem="PCQ-dy-pUZ" secondAttribute="bottom" constant="4" id="6XL-HD-4yp"/>
                                 <constraint firstAttribute="trailing" secondItem="yqt-18-HR0" secondAttribute="trailing" constant="6" id="7y7-jb-7gy"/>
                                 <constraint firstAttribute="bottom" secondItem="fDU-tM-mKk" secondAttribute="bottom" constant="9" id="Dva-Hg-ioB"/>
-                                <constraint firstAttribute="height" constant="79" id="MlO-Yr-7I8"/>
+                                <constraint firstAttribute="height" constant="85" id="MlO-Yr-7I8"/>
                                 <constraint firstItem="PCQ-dy-pUZ" firstAttribute="leading" secondItem="7c7-YZ-oiz" secondAttribute="leading" id="OA3-fw-Jui"/>
                                 <constraint firstItem="vfR-cz-NSL" firstAttribute="centerY" secondItem="yqt-18-HR0" secondAttribute="centerY" id="OgQ-aB-xBy"/>
                                 <constraint firstAttribute="bottom" secondItem="Q9K-U3-wwY" secondAttribute="bottom" constant="9" id="VYN-rV-XTf"/>
-                                <constraint firstItem="FzB-DF-mS3" firstAttribute="top" secondItem="7c7-YZ-oiz" secondAttribute="top" constant="10" id="bPm-aX-d9z"/>
+                                <constraint firstItem="FzB-DF-mS3" firstAttribute="top" secondItem="7c7-YZ-oiz" secondAttribute="top" constant="16" id="bPm-aX-d9z"/>
                                 <constraint firstItem="yqt-18-HR0" firstAttribute="leading" secondItem="FzB-DF-mS3" secondAttribute="trailing" constant="6" id="dKz-a8-jgP"/>
                                 <constraint firstAttribute="bottom" secondItem="Mas-Ji-t8P" secondAttribute="bottom" constant="9" id="hTq-uZ-Tzv"/>
                                 <constraint firstItem="vfR-cz-NSL" firstAttribute="centerX" secondItem="7c7-YZ-oiz" secondAttribute="centerX" id="jeA-PX-0KF"/>
@@ -278,7 +276,7 @@
         <image name="bucketLid" width="18" height="5"/>
         <image name="button_camera_default" width="30" height="30"/>
         <image name="button_media_default" width="30" height="30"/>
-        <image name="button_upload_default" width="30" height="30"/>
+        <image name="button_upload_default" width="30" height="30.5"/>
         <image name="lockRecording" width="30" height="30"/>
         <image name="sendVoiceClipActive" width="30" height="30"/>
         <image name="sendVoiceClipInactive" width="30" height="30"/>

--- a/JSQMessagesViewController/Views/MEGAToolbarTextContentView.xib
+++ b/JSQMessagesViewController/Views/MEGAToolbarTextContentView.xib
@@ -192,10 +192,19 @@
                                     <color key="tintColor" red="0.59215686274509804" green="0.59215686274509804" blue="0.59215686274509804" alpha="1" colorSpace="calibratedRGB"/>
                                     <state key="normal" image="button_upload_default"/>
                                 </button>
+                                <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="y5I-6X-wKb">
+                                    <rect key="frame" x="331" y="16" width="28" height="28"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" constant="28" id="R7C-xK-2aW"/>
+                                        <constraint firstAttribute="width" constant="28" id="ous-aU-yUa"/>
+                                    </constraints>
+                                    <state key="normal" title="Button" image="expand"/>
+                                </button>
                             </subviews>
                             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <constraints>
                                 <constraint firstItem="FzB-DF-mS3" firstAttribute="leading" secondItem="7c7-YZ-oiz" secondAttribute="leading" constant="16" id="06p-sS-vZy"/>
+                                <constraint firstItem="y5I-6X-wKb" firstAttribute="top" secondItem="7c7-YZ-oiz" secondAttribute="top" constant="16" id="0NO-x4-nTC"/>
                                 <constraint firstItem="Q9K-U3-wwY" firstAttribute="top" secondItem="FzB-DF-mS3" secondAttribute="bottom" constant="10" id="1iV-Dv-Tku"/>
                                 <constraint firstItem="Q9K-U3-wwY" firstAttribute="top" secondItem="PCQ-dy-pUZ" secondAttribute="bottom" constant="4" id="6XL-HD-4yp"/>
                                 <constraint firstAttribute="trailing" secondItem="yqt-18-HR0" secondAttribute="trailing" constant="6" id="7y7-jb-7gy"/>
@@ -208,6 +217,7 @@
                                 <constraint firstItem="FzB-DF-mS3" firstAttribute="top" secondItem="7c7-YZ-oiz" secondAttribute="top" constant="16" id="bPm-aX-d9z"/>
                                 <constraint firstItem="yqt-18-HR0" firstAttribute="leading" secondItem="FzB-DF-mS3" secondAttribute="trailing" constant="6" id="dKz-a8-jgP"/>
                                 <constraint firstAttribute="bottom" secondItem="Mas-Ji-t8P" secondAttribute="bottom" constant="9" id="hTq-uZ-Tzv"/>
+                                <constraint firstAttribute="trailing" secondItem="y5I-6X-wKb" secondAttribute="trailing" constant="16" id="haZ-o4-GCp"/>
                                 <constraint firstItem="vfR-cz-NSL" firstAttribute="centerX" secondItem="7c7-YZ-oiz" secondAttribute="centerX" id="jeA-PX-0KF"/>
                                 <constraint firstItem="Q9K-U3-wwY" firstAttribute="leading" secondItem="7c7-YZ-oiz" secondAttribute="leading" constant="16" id="jxc-el-ttc"/>
                                 <constraint firstItem="fDU-tM-mKk" firstAttribute="leading" secondItem="Q9K-U3-wwY" secondAttribute="trailing" constant="16" id="kj9-s9-rNQ"/>
@@ -253,6 +263,7 @@
                 <outlet property="accessoryUploadButton" destination="Mas-Ji-t8P" id="ykU-jV-TJX"/>
                 <outlet property="bodyGarbageView" destination="rjm-P1-OkQ" id="oMm-Vu-Ckq"/>
                 <outlet property="contentViewHeightConstraint" destination="MlO-Yr-7I8" id="AaH-Cp-mMW"/>
+                <outlet property="expandOrCollapseButton" destination="y5I-6X-wKb" id="i00-a2-Pmy"/>
                 <outlet property="garbageView" destination="BXC-LX-Ht2" id="88n-NF-cyg"/>
                 <outlet property="headerGarbageView" destination="ChV-AM-4dZ" id="gfx-Yl-HTk"/>
                 <outlet property="joinButton" destination="iOF-Cw-q0K" id="L0K-rG-PxW"/>
@@ -265,6 +276,7 @@
                 <outlet property="sendButton" destination="yqt-18-HR0" id="5gS-04-8WK"/>
                 <outlet property="slideToCancelButton" destination="vfR-cz-NSL" id="Khj-Ka-VPj"/>
                 <outlet property="textView" destination="FzB-DF-mS3" id="4Lm-7E-qbM"/>
+                <outlet property="textViewToTopConstraint" destination="bPm-aX-d9z" id="7t2-zB-CpD"/>
                 <outlet property="typingIndicatorLabel" destination="hZu-NL-NtO" id="Rx8-um-gIc"/>
                 <outlet property="typingIndicatorView" destination="J7o-7B-4nA" id="dwl-TV-csG"/>
             </connections>
@@ -277,6 +289,7 @@
         <image name="button_camera_default" width="30" height="30"/>
         <image name="button_media_default" width="30" height="30"/>
         <image name="button_upload_default" width="30" height="30.5"/>
+        <image name="expand" width="28" height="28.5"/>
         <image name="lockRecording" width="30" height="30"/>
         <image name="sendVoiceClipActive" width="30" height="30"/>
         <image name="sendVoiceClipInactive" width="30" height="30"/>

--- a/JSQMessagesViewController/Views/MEGAToolbarTextContentView.xib
+++ b/JSQMessagesViewController/Views/MEGAToolbarTextContentView.xib
@@ -107,6 +107,13 @@
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7c7-YZ-oiz">
                             <rect key="frame" x="0.0" y="75" width="375" height="85"/>
                             <subviews>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="wnF-Hj-87m">
+                                    <rect key="frame" x="16" y="8" width="240" height="0.0"/>
+                                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" id="Bpo-Z5-Bh4"/>
+                                    </constraints>
+                                </view>
                                 <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="FzB-DF-mS3" customClass="JSQMessagesComposerTextView">
                                     <rect key="frame" x="16" y="16" width="297" height="20"/>
                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -206,6 +213,7 @@
                                 <constraint firstItem="FzB-DF-mS3" firstAttribute="leading" secondItem="7c7-YZ-oiz" secondAttribute="leading" constant="16" id="06p-sS-vZy"/>
                                 <constraint firstItem="y5I-6X-wKb" firstAttribute="top" secondItem="7c7-YZ-oiz" secondAttribute="top" constant="16" id="0NO-x4-nTC"/>
                                 <constraint firstItem="Q9K-U3-wwY" firstAttribute="top" secondItem="FzB-DF-mS3" secondAttribute="bottom" constant="10" id="1iV-Dv-Tku"/>
+                                <constraint firstItem="wnF-Hj-87m" firstAttribute="leading" secondItem="7c7-YZ-oiz" secondAttribute="leading" constant="16" id="3sF-Jd-0mm"/>
                                 <constraint firstItem="Q9K-U3-wwY" firstAttribute="top" secondItem="PCQ-dy-pUZ" secondAttribute="bottom" constant="4" id="6XL-HD-4yp"/>
                                 <constraint firstAttribute="trailing" secondItem="yqt-18-HR0" secondAttribute="trailing" constant="6" id="7y7-jb-7gy"/>
                                 <constraint firstAttribute="bottom" secondItem="fDU-tM-mKk" secondAttribute="bottom" constant="9" id="Dva-Hg-ioB"/>
@@ -213,8 +221,9 @@
                                 <constraint firstAttribute="height" constant="85" id="MlO-Yr-7I8"/>
                                 <constraint firstItem="PCQ-dy-pUZ" firstAttribute="leading" secondItem="7c7-YZ-oiz" secondAttribute="leading" id="OA3-fw-Jui"/>
                                 <constraint firstItem="vfR-cz-NSL" firstAttribute="centerY" secondItem="yqt-18-HR0" secondAttribute="centerY" id="OgQ-aB-xBy"/>
+                                <constraint firstItem="wnF-Hj-87m" firstAttribute="width" secondItem="FzB-DF-mS3" secondAttribute="width" multiplier="0.808081" id="Q9o-n4-wrM"/>
                                 <constraint firstAttribute="bottom" secondItem="Q9K-U3-wwY" secondAttribute="bottom" constant="9" id="VYN-rV-XTf"/>
-                                <constraint firstItem="FzB-DF-mS3" firstAttribute="top" secondItem="7c7-YZ-oiz" secondAttribute="top" constant="16" id="bPm-aX-d9z"/>
+                                <constraint firstItem="wnF-Hj-87m" firstAttribute="top" secondItem="7c7-YZ-oiz" secondAttribute="top" constant="8" id="aXk-Mu-L3t"/>
                                 <constraint firstItem="yqt-18-HR0" firstAttribute="leading" secondItem="FzB-DF-mS3" secondAttribute="trailing" constant="6" id="dKz-a8-jgP"/>
                                 <constraint firstAttribute="bottom" secondItem="Mas-Ji-t8P" secondAttribute="bottom" constant="9" id="hTq-uZ-Tzv"/>
                                 <constraint firstAttribute="trailing" secondItem="y5I-6X-wKb" secondAttribute="trailing" constant="16" id="haZ-o4-GCp"/>
@@ -223,6 +232,7 @@
                                 <constraint firstItem="fDU-tM-mKk" firstAttribute="leading" secondItem="Q9K-U3-wwY" secondAttribute="trailing" constant="16" id="kj9-s9-rNQ"/>
                                 <constraint firstItem="PCQ-dy-pUZ" firstAttribute="top" secondItem="7c7-YZ-oiz" secondAttribute="top" id="neP-Yt-umR"/>
                                 <constraint firstItem="Mas-Ji-t8P" firstAttribute="leading" secondItem="fDU-tM-mKk" secondAttribute="trailing" constant="16" id="vKJ-U6-uli"/>
+                                <constraint firstItem="FzB-DF-mS3" firstAttribute="top" secondItem="wnF-Hj-87m" secondAttribute="bottom" constant="8" id="xmz-uo-9kY"/>
                             </constraints>
                         </view>
                     </subviews>
@@ -263,6 +273,8 @@
                 <outlet property="accessoryUploadButton" destination="Mas-Ji-t8P" id="ykU-jV-TJX"/>
                 <outlet property="bodyGarbageView" destination="rjm-P1-OkQ" id="oMm-Vu-Ckq"/>
                 <outlet property="contentViewHeightConstraint" destination="MlO-Yr-7I8" id="AaH-Cp-mMW"/>
+                <outlet property="draggableView" destination="wnF-Hj-87m" id="0Ij-6z-puy"/>
+                <outlet property="draggableViewHeightConstraint" destination="Bpo-Z5-Bh4" id="CDW-8w-iUo"/>
                 <outlet property="expandOrCollapseButton" destination="y5I-6X-wKb" id="i00-a2-Pmy"/>
                 <outlet property="garbageView" destination="BXC-LX-Ht2" id="88n-NF-cyg"/>
                 <outlet property="headerGarbageView" destination="ChV-AM-4dZ" id="gfx-Yl-HTk"/>
@@ -276,7 +288,6 @@
                 <outlet property="sendButton" destination="yqt-18-HR0" id="5gS-04-8WK"/>
                 <outlet property="slideToCancelButton" destination="vfR-cz-NSL" id="Khj-Ka-VPj"/>
                 <outlet property="textView" destination="FzB-DF-mS3" id="4Lm-7E-qbM"/>
-                <outlet property="textViewToTopConstraint" destination="bPm-aX-d9z" id="7t2-zB-CpD"/>
                 <outlet property="typingIndicatorLabel" destination="hZu-NL-NtO" id="Rx8-um-gIc"/>
                 <outlet property="typingIndicatorView" destination="J7o-7B-4nA" id="dwl-TV-csG"/>
             </connections>


### PR DESCRIPTION
- Now the max number of lines displayed in the input text view is five.
- The chat toolbar can now be expanded when there are more than five lines in the input text view.
- The upper gap between the input text view and the toolbar is bigger.

Issue: https://issues.developers.mega.co.nz/issues/13749
InVision project: https://projects.invisionapp.com/d/main/#/console/18183157/377446623/preview#project_console
Freehand: https://projects.invisionapp.com/freehand/document/fT3cJzQzN