### PR TITLE
Task/#13911 enable the pasting of images directly into chat

### DIFF
--- a/JSQMessagesViewController/Views/JSQMessagesComposerTextView.m
+++ b/JSQMessagesViewController/Views/JSQMessagesComposerTextView.m
@@ -287,8 +287,12 @@
     return [super becomeFirstResponder];
 }
 
-- (BOOL)canPerformAction:(SEL)action withSender:(id)sender {
+- (BOOL)canPerformAction:(SEL)action withSender:(id)sender
+{
     [UIMenuController sharedMenuController].menuItems = nil;
+    if (action == @selector(paste:)) {
+        return [UIPasteboard generalPasteboard].string != nil || [UIPasteboard generalPasteboard].image != nil;
+    }
     return [super canPerformAction:action withSender:sender];
 }
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
When copying an image on iOS you can paste it directly into chat messages. In other applications this then pastes the image into the message and you can send it. However, on MEGA if you paste the image nothing happens. Can we please make it work the same as other applications?


Does this close any currently open issues?
------------------------------------------
https://issues.developers.mega.co.nz/issues/13911
https://github.com/meganz/iOS_dev/pull/476 
