### PR TITLE
fix typing tip view overlapping message bubble

### DIFF
--- a/JSQMessagesViewController/Views/MEGAInputToolbar.m
+++ b/JSQMessagesViewController/Views/MEGAInputToolbar.m
@@ -619,7 +619,7 @@ typedef NS_ENUM(NSUInteger, InputToolbarMode) {
     CGFloat newToolbarHeight = [self heightToFitInWidth:self.contentView.textView.frame.size.width];
     self.contentView.contentViewHeightConstraint.constant = newToolbarHeight;
     [self.contentView layoutIfNeeded];
-    [self.delegate messagesInputToolbar:self needsResizeToHeight:newToolbarHeight];
+    [self.delegate messagesInputToolbar:self needsResizeToHeight:newToolbarHeight + (self.contentView.typingIndicatorView.hidden ? 0 : self.contentView.typingIndicatorView.frame.size.height)];
 }
 
 - (CGFloat)heightToFitInWidth:(CGFloat)width {


### PR DESCRIPTION
 What's in this pull request?
fix 
typing-view-overlapping-message-bubble 
https://issues.developers.mega.co.nz/issues/14565