### PR TITLE
Expanded area should shrink

### DIFF
--- a/JSQMessagesViewController/Views/MEGAInputToolbar.m
+++ b/JSQMessagesViewController/Views/MEGAInputToolbar.m
@@ -181,6 +181,9 @@ typedef NS_ENUM(NSUInteger, InputToolbarMode) {
                 break;
                 
             case InputToolbarStateWriting:
+                if (self.currentMode == InputToolbarModeExpanded) {
+                    [self mnz_expandOrCollapseButtonPressed];
+                }
                 [self.delegate messagesInputToolbar:self didPressSendButton:sender];
                 break;
                 


### PR DESCRIPTION
bug(chat): The expanded area should shrink to the default state after the message is sent

https://issues.developers.mega.co.nz/issues/15381
